### PR TITLE
Fixed a bug that could have caused bitcore to be loaded twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ function startGulp(name, opts) {
 
     if (isSubmodule) {
       browserifyCommand = './node_modules/.bin/browserify --require index.js:' + fullname + ' --external bitcore -o ' + fullname + '.js';
+      console.log(browserifyCommand);
     } else {
       browserifyCommand = './node_modules/.bin/browserify --require index.js:bitcore -o bitcore.js';
     }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,6 @@ function startGulp(name, opts) {
 
     if (isSubmodule) {
       browserifyCommand = './node_modules/.bin/browserify --require ./index.js:' + fullname + ' --external bitcore -o ' + fullname + '.js';
-      console.log(browserifyCommand);
     } else {
       browserifyCommand = './node_modules/.bin/browserify --require ./index.js:bitcore -o bitcore.js';
     }

--- a/index.js
+++ b/index.js
@@ -96,10 +96,10 @@ function startGulp(name, opts) {
     var browserifyCommand;
 
     if (isSubmodule) {
-      browserifyCommand = './node_modules/.bin/browserify --require index.js:' + fullname + ' --external bitcore -o ' + fullname + '.js';
+      browserifyCommand = './node_modules/.bin/browserify --require ./index.js:' + fullname + ' --external bitcore -o ' + fullname + '.js';
       console.log(browserifyCommand);
     } else {
-      browserifyCommand = './node_modules/.bin/browserify --require index.js:bitcore -o bitcore.js';
+      browserifyCommand = './node_modules/.bin/browserify --require ./index.js:bitcore -o bitcore.js';
     }
 
     gulp.task('browser:uncompressed', shell.task([

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function startGulp(name, opts) {
 
   opts = opts || {};
   var browser = !opts.skipBrowser;
+  var isSubmodule = name ? true : false;
   var fullname = name ? 'bitcore-' + name : 'bitcore';
   var files = ['lib/**/*.js'];
   var tests = ['test/**/*.js'];
@@ -91,9 +92,17 @@ function startGulp(name, opts) {
    * file generation
    */
   if (browser) {
+
+    var browserifyCommand;
+
+    if (isSubmodule) {
+      browserifyCommand = './node_modules/.bin/browserify --require index.js:' + fullname + ' --external bitcore -o ' + fullname + '.js';
+    } else {
+      browserifyCommand = './node_modules/.bin/browserify --require index.js:bitcore -o bitcore.js';
+    }
+
     gulp.task('browser:uncompressed', shell.task([
-      './node_modules/.bin/browserify index.js --insert-global-vars=true --standalone=' +
-      fullname + ' -o ' + fullname + '.js'
+      browserifyCommand
     ]));
 
     gulp.task('browser:compressed', ['browser:uncompressed'], function() {


### PR DESCRIPTION
- 'bitcore' in a browser will be accessible via `require('bitcore')` rather than at `window.bitcore`
- submodules that use `require('bitcore')` can use bitcore loaded from a seperate file (or concatenated)
