### PR TITLE
Use bitpay's version of karma.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gulp-uglify": "^1.0.2",
     "gulp-util": "=3.0.1",
     "istanbul": "^0.3.5",
-    "karma": "^0.12.28",
+    "karma": "https://github.com/bitpay/karma#bitpay-v0.12.37",
     "karma-chrome-launcher": "^0.1.8",
     "karma-detect-browsers": "^2.0.0",
     "karma-firefox-launcher": "^0.1.4",


### PR DESCRIPTION
- So karma can point to BP socket.io...eventually to support prebuilds at the web sockets level
