### PR TITLE
Use 'git+https' URL instead of just 'https' URL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gulp-uglify": "^1.0.2",
     "gulp-util": "=3.0.1",
     "istanbul": "^0.3.5",
-    "karma": "https://github.com/bitpay/karma#bitpay-v0.12.37",
+    "karma": "git+https://github.com/bitpay/karma#bitpay-v0.12.37",
     "karma-chrome-launcher": "^0.1.8",
     "karma-detect-browsers": "^2.0.0",
     "karma-firefox-launcher": "^0.1.4",


### PR DESCRIPTION
Without this, "npm install" checks out the github HTML for karma, instead of the actual repo.
