### PR TITLE
Fix double bitcore-lib loading issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function startGulp(name, opts) {
     var browserifyCommand;
 
     if (isSubmodule) {
-      browserifyCommand = buildBinPath + 'browserify --require ./index.js:' + fullname + ' --external bitcore -o ' + fullname + '.js';
+      browserifyCommand = buildBinPath + 'browserify --require ./index.js:' + fullname + ' --external bitcore-lib -o ' + fullname + '.js';
     } else {
       browserifyCommand = buildBinPath + 'browserify --require ./index.js:bitcore -o bitcore.js';
     }


### PR DESCRIPTION
Browserify has an option to exclude a library from the browser package
so that it can be loaded only once, previously we used `--external bitcore`
however now we need to use `--external bitcore-lib` as the package has
been renamed.
